### PR TITLE
Do not serialize value <-> number mapping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ exclude = [
 [dependencies]
 serde = "1"
 serde_derive = "1"
+
+[dev-dependencies]
+serde_cbor = "0.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,55 @@ use std::hash::Hash;
 
 use serde_derive::{Deserialize, Serialize};
 
-/// Numberer for categorical values, such as features or class labels.
+/// Serialized representation for `Numberer`.
+///
+/// This exists because we do not need to serialize both the
+/// `values` and `numbers` fields of `Numberer`, since they
+/// represent the same information.
 #[derive(Eq, PartialEq, Serialize, Deserialize)]
+struct SerializedNumberer<T> {
+    values: Vec<T>,
+    start_at: usize,
+}
+
+impl<T> From<Numberer<T>> for SerializedNumberer<T>
+where
+    T: Clone + Eq + Hash,
+{
+    fn from(numberer: Numberer<T>) -> Self {
+        SerializedNumberer {
+            values: numberer.values,
+            start_at: numberer.start_at,
+        }
+    }
+}
+
+impl<T> From<SerializedNumberer<T>> for Numberer<T>
+where
+    T: Clone + Eq + Hash,
+{
+    fn from(serialized_numberer: SerializedNumberer<T>) -> Self {
+        let numbers = serialized_numberer
+            .values
+            .iter()
+            .enumerate()
+            .map(|(idx, val)| (val.clone(), idx + serialized_numberer.start_at))
+            .collect();
+
+        Numberer {
+            numbers,
+            values: serialized_numberer.values,
+            start_at: serialized_numberer.start_at,
+        }
+    }
+}
+
+/// Numberer for categorical values, such as features or class labels.
+#[serde(from = "SerializedNumberer<T>", into = "SerializedNumberer<T>")]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Numberer<T>
 where
-    T: Eq + Hash,
+    T: Clone + Eq + Hash,
 {
     values: Vec<T>,
     numbers: HashMap<T, usize>,
@@ -62,5 +106,28 @@ where
     /// Return the value for a number.
     pub fn value(&self, number: usize) -> Option<&T> {
         self.values.get(number - self.start_at)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::Numberer;
+
+    #[test]
+    fn serialization_roundtrip_results_in_same_numberer() {
+        let mut numberer = Numberer::new(13);
+        numberer.add("hello".to_string());
+        numberer.add("world".to_string());
+        numberer.add("!".to_string());
+
+        let mut serialized = Vec::new();
+        serde_cbor::to_writer(&mut serialized, &numberer).unwrap();
+
+        let serialized = Cursor::new(serialized);
+        let numberer_deserialized: Numberer<String> = serde_cbor::from_reader(serialized).unwrap();
+
+        assert_eq!(numberer, numberer_deserialized);
     }
 }


### PR DESCRIPTION
This mapping can be reconstructed from the values and the starting
index.